### PR TITLE
pytest-sugar 1.1.1 rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,8 +24,8 @@ requirements:
   run:
     - python
     - packaging >=21.3
-    - pytest >=6.2.0
     - termcolor >=2.1.0
+    - pytest >=6.2.5
 
 test:
   source_files:
@@ -38,7 +38,8 @@ test:
     - pytest -v
   requires:
     - pip
-    - pytest
+    # https://github.com/Teemu/pytest-sugar/blob/v1.1.1/tox.ini#L10
+    - pytest >=6.2.5,<7.0.0
 
 about:
   home: https://github.com/Teemu/pytest-sugar

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 73b8b65163ebf10f9f671efab9eed3d56f20d2ca68bda83fa64740a92c08f65d
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: True  #[py<38]
 
@@ -24,8 +24,12 @@ requirements:
   run:
     - python
     - packaging >=21.3
+    # Package uses hook which is removed in pytest>=9
+    # https://docs.pytest.org/en/latest/deprecations.html#py-path-local-arguments-for-hooks-replaced-with-pathlib-path
+    # !! Important: Support for pytest>=9 will be added in next release !!
+    # https://github.com/Teemu/pytest-sugar/pull/301
+    - pytest >=6.2.0,<9
     - termcolor >=2.1.0
-    - pytest >=6.2.5
 
 test:
   source_files:
@@ -38,8 +42,7 @@ test:
     - pytest -v
   requires:
     - pip
-    # https://github.com/Teemu/pytest-sugar/blob/v1.1.1/tox.ini#L10
-    - pytest >=6.2.5,<7.0.0
+    - pytest
 
 about:
   home: https://github.com/Teemu/pytest-sugar


### PR DESCRIPTION
pytest-sugar 1.1.1

**Destination channel:** Defaults

### Links

- [PKG-12281]
- dev_url:        https://github.com/Teemu/pytest-sugar/tree/main
- conda_forge:    https://github.com/conda-forge/pytest-sugar-feedstock
- pypi:           https://pypi.org/project/pytest-sugar/1.1.1
- pypi inspector: https://inspector.pypi.io/project/pytest-sugar/1.1.1

### Explanation of changes:

- add upper bound for pytest due to usage of removed hook


[PKG-12281]: https://anaconda.atlassian.net/browse/PKG-12281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ